### PR TITLE
Feature gate zstd

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -49,7 +49,7 @@ serde_json.workspace = true
 sha2 = { version = "0.10.7", optional = true }
 tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
-zstd = { version = "0.12", features = ["experimental"] }
+zstd = { version = "0.12", features = ["experimental"], optional = true }
 roaring = "0.10.2"
 cfg-if = "1.0.0"
 
@@ -90,7 +90,7 @@ pprof = { workspace = true, features = ["flamegraph", "frame-pointer", "criterio
 secp256k1.workspace = true
 
 [features]
-default = ["c-kzg"]
+default = ["c-kzg", "zstd-codec"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 arbitrary = [
     "revm-primitives/arbitrary",
@@ -102,8 +102,12 @@ arbitrary = [
     "dep:arbitrary",
     "dep:proptest",
     "dep:proptest-derive",
+    "zstd-codec"
 ]
 c-kzg = ["dep:c-kzg", "revm/c-kzg", "revm-primitives/c-kzg", "dep:sha2", "dep:tempfile"]
+zstd-codec = [
+    "dep:zstd"
+]
 clap = ["dep:clap"]
 optimism = [
     "reth-codecs/optimism",

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -21,6 +21,7 @@ mod account;
 pub mod basefee;
 mod block;
 mod chain;
+#[cfg(feature = "zstd-codec")]
 mod compression;
 pub mod constants;
 pub mod eip4844;
@@ -58,6 +59,7 @@ pub use chain::{
     ChainSpecBuilder, DisplayHardforks, ForkBaseFeeParams, ForkCondition, ForkTimestamps,
     NamedChain, DEV, GOERLI, HOLESKY, MAINNET, SEPOLIA,
 };
+#[cfg(feature = "zstd-codec")]
 pub use compression::*;
 pub use constants::{
     DEV_GENESIS_HASH, EMPTY_OMMER_ROOT_HASH, GOERLI_GENESIS_HASH, HOLESKY_GENESIS_HASH,

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -1,19 +1,23 @@
 use crate::{
-    compression::{RECEIPT_COMPRESSOR, RECEIPT_DECOMPRESSOR},
     logs_bloom, Bloom, Bytes, Log, PruneSegmentError, TxType, B256,
 };
+#[cfg(feature = "zstd-codec")]
+use crate::compression::{RECEIPT_COMPRESSOR, RECEIPT_DECOMPRESSOR};
 use alloy_rlp::{length_of_length, Decodable, Encodable};
 use bytes::{Buf, BufMut};
 #[cfg(any(test, feature = "arbitrary"))]
 use proptest::strategy::Strategy;
-use reth_codecs::{add_arbitrary_tests, main_codec, Compact, CompactZstd};
+use reth_codecs::{add_arbitrary_tests, main_codec, Compact};
+#[cfg(feature = "zstd-codec")]
+use reth_codecs::CompactZstd;
 use std::{
     cmp::Ordering,
     ops::{Deref, DerefMut},
 };
 
 /// Receipt containing result of transaction execution.
-#[main_codec(no_arbitrary, zstd)]
+#[cfg_attr(feature = "zstd-codec", main_codec(no_arbitrary, zstd))]
+#[cfg_attr(not(feature = "zstd-codec"), main_codec(no_arbitrary))]
 #[add_arbitrary_tests]
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct Receipt {

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -1,15 +1,13 @@
-use crate::{
-    logs_bloom, Bloom, Bytes, Log, PruneSegmentError, TxType, B256,
-};
 #[cfg(feature = "zstd-codec")]
 use crate::compression::{RECEIPT_COMPRESSOR, RECEIPT_DECOMPRESSOR};
+use crate::{logs_bloom, Bloom, Bytes, Log, PruneSegmentError, TxType, B256};
 use alloy_rlp::{length_of_length, Decodable, Encodable};
 use bytes::{Buf, BufMut};
 #[cfg(any(test, feature = "arbitrary"))]
 use proptest::strategy::Strategy;
-use reth_codecs::{add_arbitrary_tests, main_codec, Compact};
 #[cfg(feature = "zstd-codec")]
 use reth_codecs::CompactZstd;
+use reth_codecs::{add_arbitrary_tests, main_codec, Compact};
 use std::{
     cmp::Ordering,
     ops::{Deref, DerefMut},

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -387,7 +387,7 @@ impl Transaction {
 
         // Check if max_fee_per_gas is less than base_fee
         if max_fee_per_gas < base_fee {
-            return None;
+            return None
         }
 
         // Calculate the difference between max_fee_per_gas and base_fee
@@ -1064,7 +1064,7 @@ impl TransactionSigned {
         // `from` address.
         #[cfg(feature = "optimism")]
         if let Transaction::Deposit(TxDeposit { from, .. }) = self.transaction {
-            return Some(from);
+            return Some(from)
         }
         let signature_hash = self.signature_hash();
         self.signature.recover_signer(signature_hash)
@@ -1080,7 +1080,7 @@ impl TransactionSigned {
         // `from` address.
         #[cfg(feature = "optimism")]
         if let Transaction::Deposit(TxDeposit { from, .. }) = self.transaction {
-            return Some(from);
+            return Some(from)
         }
         let signature_hash = self.signature_hash();
         self.signature.recover_signer_unchecked(signature_hash)
@@ -1254,7 +1254,7 @@ impl TransactionSigned {
         let transaction_payload_len = header.payload_length;
 
         if transaction_payload_len > remaining_len {
-            return Err(RlpError::InputTooShort);
+            return Err(RlpError::InputTooShort)
         }
 
         let mut transaction = TxLegacy {
@@ -1272,7 +1272,7 @@ impl TransactionSigned {
         // check the new length, compared to the original length and the header length
         let decoded = remaining_len - data.len();
         if decoded != transaction_payload_len {
-            return Err(RlpError::UnexpectedLength);
+            return Err(RlpError::UnexpectedLength)
         }
 
         let tx_length = header.payload_length + header.length();
@@ -1321,7 +1321,7 @@ impl TransactionSigned {
         // decode the list header for the rest of the transaction
         let header = Header::decode(data)?;
         if !header.list {
-            return Err(RlpError::Custom("typed tx fields must be encoded as a list"));
+            return Err(RlpError::Custom("typed tx fields must be encoded as a list"))
         }
 
         let remaining_len = data.len();
@@ -1331,7 +1331,7 @@ impl TransactionSigned {
 
         // decode common fields
         let Ok(tx_type) = TxType::try_from(tx_type) else {
-            return Err(RlpError::Custom("unsupported typed transaction type"));
+            return Err(RlpError::Custom("unsupported typed transaction type"))
         };
         let transaction = match tx_type {
             TxType::Eip2930 => Transaction::Eip2930(TxEip2930::decode_inner(data)?),
@@ -1354,7 +1354,7 @@ impl TransactionSigned {
 
         let bytes_consumed = remaining_len - data.len();
         if bytes_consumed != header.payload_length {
-            return Err(RlpError::UnexpectedLength);
+            return Err(RlpError::UnexpectedLength)
         }
 
         let hash = keccak256(&original_encoding_without_header[..tx_length]);
@@ -1381,7 +1381,7 @@ impl TransactionSigned {
     /// [PooledTransactionsElement::decode_enveloped].
     pub fn decode_enveloped(data: &mut &[u8]) -> alloy_rlp::Result<Self> {
         if data.is_empty() {
-            return Err(RlpError::InputTooShort);
+            return Err(RlpError::InputTooShort)
         }
 
         // Check if the tx is a list
@@ -1483,7 +1483,7 @@ impl Decodable for TransactionSigned {
             // string Header with payload_length of 1, we need to make sure this check is only
             // performed for transactions with a string header
             if bytes_consumed != header.payload_length && original_encoding[0] > EMPTY_STRING_CODE {
-                return Err(RlpError::UnexpectedLength);
+                return Err(RlpError::UnexpectedLength)
             }
 
             Ok(tx)

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -616,8 +616,8 @@ impl Compact for Transaction {
     // Serializes the TxType to the buffer if necessary, returning 2 bits of the type as an
     // identifier instead of the length.
     fn to_compact<B>(self, buf: &mut B) -> usize
-        where
-            B: bytes::BufMut + AsMut<[u8]>,
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
     {
         let identifier = self.tx_type().to_compact(buf);
         match self {
@@ -766,8 +766,8 @@ impl TransactionKind {
 
 impl Compact for TransactionKind {
     fn to_compact<B>(self, buf: &mut B) -> usize
-        where
-            B: bytes::BufMut + AsMut<[u8]>,
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
     {
         match self {
             TransactionKind::Create => 0,
@@ -874,8 +874,8 @@ impl TransactionSignedNoHash {
     /// Returns `None`, if some transaction's signature is invalid, see also
     /// [Self::recover_signer].
     pub fn recover_signers<'a, T>(txes: T, num_txes: usize) -> Option<Vec<Address>>
-        where
-            T: IntoParallelIterator<Item=&'a Self> + IntoIterator<Item=&'a Self> + Send,
+    where
+        T: IntoParallelIterator<Item = &'a Self> + IntoIterator<Item = &'a Self> + Send,
     {
         if num_txes < *PARALLEL_SENDER_RECOVERY_THRESHOLD {
             txes.into_iter().map(|tx| tx.recover_signer()).collect()
@@ -888,8 +888,8 @@ impl TransactionSignedNoHash {
 #[cfg(feature = "zstd-codec")]
 impl Compact for TransactionSignedNoHash {
     fn to_compact<B>(self, buf: &mut B) -> usize
-        where
-            B: bytes::BufMut + AsMut<[u8]>,
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
     {
         let start = buf.as_mut().len();
 
@@ -951,8 +951,8 @@ impl Compact for TransactionSignedNoHash {
 #[cfg(not(feature = "zstd-codec"))]
 impl Compact for TransactionSignedNoHash {
     fn to_compact<B>(self, buf: &mut B) -> usize
-        where
-            B: bytes::BufMut + AsMut<[u8]>,
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
     {
         to_compact_ztd_unaware(self, buf)
     }
@@ -965,8 +965,8 @@ impl Compact for TransactionSignedNoHash {
 // Allowing dead code, as this function is extracted from behind feature, so it can be tested
 #[allow(dead_code)]
 fn to_compact_ztd_unaware<B>(transaction: TransactionSignedNoHash, buf: &mut B) -> usize
-    where
-        B: bytes::BufMut + AsMut<[u8]>
+where
+    B: bytes::BufMut + AsMut<[u8]>,
 {
     let start = buf.as_mut().len();
 
@@ -1005,7 +1005,6 @@ fn from_compact_zstd_unaware(mut buf: &[u8], _len: usize) -> (TransactionSignedN
 
     (TransactionSignedNoHash { signature, transaction }, buf)
 }
-
 
 impl From<TransactionSignedNoHash> for TransactionSigned {
     fn from(tx: TransactionSignedNoHash) -> Self {
@@ -1092,8 +1091,8 @@ impl TransactionSigned {
     /// Returns `None`, if some transaction's signature is invalid, see also
     /// [Self::recover_signer].
     pub fn recover_signers<'a, T>(txes: T, num_txes: usize) -> Option<Vec<Address>>
-        where
-            T: IntoParallelIterator<Item=&'a Self> + IntoIterator<Item=&'a Self> + Send,
+    where
+        T: IntoParallelIterator<Item = &'a Self> + IntoIterator<Item = &'a Self> + Send,
     {
         if num_txes < *PARALLEL_SENDER_RECOVERY_THRESHOLD {
             txes.into_iter().map(|tx| tx.recover_signer()).collect()
@@ -1108,8 +1107,8 @@ impl TransactionSigned {
     /// Returns `None`, if some transaction's signature is invalid, see also
     /// [Self::recover_signer_unchecked].
     pub fn recover_signers_unchecked<'a, T>(txes: T, num_txes: usize) -> Option<Vec<Address>>
-        where
-            T: IntoParallelIterator<Item=&'a Self> + IntoIterator<Item=&'a Self>,
+    where
+        T: IntoParallelIterator<Item = &'a Self> + IntoIterator<Item = &'a Self>,
     {
         if num_txes < *PARALLEL_SENDER_RECOVERY_THRESHOLD {
             txes.into_iter().map(|tx| tx.recover_signer_unchecked()).collect()
@@ -1344,10 +1343,10 @@ impl TransactionSigned {
         };
 
         #[cfg(not(feature = "optimism"))]
-            let signature = Signature::decode(data)?;
+        let signature = Signature::decode(data)?;
 
         #[cfg(feature = "optimism")]
-            let signature = if tx_type == TxType::Deposit {
+        let signature = if tx_type == TxType::Deposit {
             Signature::optimism_deposit_tx_signature()
         } else {
             Signature::decode(data)?
@@ -1513,7 +1512,7 @@ impl proptest::arbitrary::Arbitrary for TransactionSigned {
                 }
 
                 #[cfg(feature = "optimism")]
-                    let sig = transaction
+                let sig = transaction
                     .is_deposit()
                     .then(Signature::optimism_deposit_tx_signature)
                     .unwrap_or(sig);
@@ -1541,7 +1540,7 @@ impl<'a> arbitrary::Arbitrary<'a> for TransactionSigned {
         let signature = Signature::arbitrary(u)?;
 
         #[cfg(feature = "optimism")]
-            let signature = if transaction.is_deposit() {
+        let signature = if transaction.is_deposit() {
             Signature::optimism_deposit_tx_signature()
         } else {
             signature
@@ -1660,19 +1659,23 @@ impl IntoRecoveredTransaction for TransactionSignedEcRecovered {
 
 #[cfg(test)]
 mod tests {
-    use crate::{hex, sign_message, transaction::{
-        signature::Signature, TransactionKind, TxEip1559, TxLegacy,
-        MIN_LENGTH_EIP1559_TX_ENCODED, MIN_LENGTH_EIP2930_TX_ENCODED,
-        MIN_LENGTH_EIP4844_TX_ENCODED, MIN_LENGTH_LEGACY_TX_ENCODED,
-        PARALLEL_SENDER_RECOVERY_THRESHOLD,
-    }, Address, Bytes, Transaction, TransactionSigned, TransactionSignedEcRecovered, TxEip2930, TxEip4844, B256, U256, TransactionSignedNoHash};
+    use crate::{
+        hex, sign_message,
+        transaction::{
+            from_compact_zstd_unaware, signature::Signature, to_compact_ztd_unaware,
+            TransactionKind, TxEip1559, TxLegacy, MIN_LENGTH_EIP1559_TX_ENCODED,
+            MIN_LENGTH_EIP2930_TX_ENCODED, MIN_LENGTH_EIP4844_TX_ENCODED,
+            MIN_LENGTH_LEGACY_TX_ENCODED, PARALLEL_SENDER_RECOVERY_THRESHOLD,
+        },
+        Address, Bytes, Transaction, TransactionSigned, TransactionSignedEcRecovered,
+        TransactionSignedNoHash, TxEip2930, TxEip4844, B256, U256,
+    };
     use alloy_primitives::{address, b256, bytes};
     use alloy_rlp::{Decodable, Encodable, Error as RlpError};
     use bytes::BytesMut;
+    use reth_codecs::Compact;
     use secp256k1::{KeyPair, Secp256k1};
     use std::str::FromStr;
-    use reth_codecs::Compact;
-    use crate::transaction::{from_compact_zstd_unaware, to_compact_ztd_unaware};
 
     #[test]
     fn test_decode_empty_typed_tx() {
@@ -2132,10 +2135,7 @@ mod tests {
                 input: Bytes::from(input),
             });
 
-            let tx_signed_no_hash = TransactionSignedNoHash {
-                signature,
-                transaction,
-            };
+            let tx_signed_no_hash = TransactionSignedNoHash { signature, transaction };
             test_transaction_signed_to_from_compact(tx_signed_no_hash);
         }
     }
@@ -2161,7 +2161,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "zstd-codec feature is not enabled, cannot decode `TransactionSignedNoHash` with zstd flag")]
+    #[should_panic(
+        expected = "zstd-codec feature is not enabled, cannot decode `TransactionSignedNoHash` with zstd flag"
+    )]
     fn transaction_signed_zstd_encoded_no_zstd_decode() {
         let signature = Signature {
             odd_y_parity: false,
@@ -2181,10 +2183,7 @@ mod tests {
             value: U256::from(1000000000000000u64),
             input: Bytes::from(vec![3u8; 64]),
         });
-        let tx_signed_no_hash = TransactionSignedNoHash {
-            signature,
-            transaction,
-        };
+        let tx_signed_no_hash = TransactionSignedNoHash { signature, transaction };
 
         let mut buff: Vec<u8> = Vec::new();
         let written_bytes = tx_signed_no_hash.to_compact(&mut buff);


### PR DESCRIPTION
This PR introduces a new default feature called `zstd-codec`.

Purpose of this feature is to allow using `reth-primitive` crates without zstd compression, in environments, where it is not beneficial, for example in ZK targets, such as risc0.

