### PR TITLE
`reth-primitives` exclude tokio from non default features

### DIFF
--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -12,10 +12,8 @@ use reth_discv4::{Discv4Config, Discv4ConfigBuilder, NatResolver, DEFAULT_DISCOV
 use reth_discv5::NetworkStackId;
 use reth_dns_discovery::DnsDiscoveryConfig;
 use reth_eth_wire::{HelloMessage, HelloMessageWithProtocols, Status};
-use reth_network_peers::{pk2id, PeerId};
-use reth_primitives::{
-    mainnet_nodes, sepolia_nodes, ChainSpec, ForkFilter, Head, TrustedPeer, MAINNET,
-};
+use reth_network_peers::{pk2id, PeerId, TrustedPeer};
+use reth_primitives::{mainnet_nodes, sepolia_nodes, ChainSpec, ForkFilter, Head, MAINNET};
 use reth_provider::{BlockReader, HeaderProvider};
 use reth_tasks::{TaskSpawner, TokioTaskExecutor};
 use secp256k1::SECP256K1;

--- a/crates/net/peers/Cargo.toml
+++ b/crates/net/peers/Cargo.toml
@@ -25,7 +25,7 @@ secp256k1 = { workspace = true, optional = true }
 serde_with.workspace = true
 thiserror.workspace = true
 url.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["full"], optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["rand"] }
@@ -34,4 +34,8 @@ secp256k1 = { workspace = true, features = ["rand"] }
 serde_json.workspace = true
 
 [features]
+default = ["resolve_peer_dns"]
+resolve_peer_dns = [
+    "dep:tokio"
+]
 secp256k1 = ["dep:secp256k1"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -87,7 +87,7 @@ pprof = { workspace = true, features = [
 secp256k1.workspace = true
 
 [features]
-default = ["c-kzg", "zstd-codec", "alloy-compat"]
+default = ["c-kzg", "zstd-codec", "alloy-compat", "reth-network-peers/default"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 arbitrary = [
     "reth-primitives-traits/arbitrary",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -24,7 +24,7 @@ revm-primitives = { workspace = true, features = ["serde"] }
 
 # ethereum
 alloy-chains = { workspace = true, features = ["serde", "rlp"] }
-alloy-consensus = { workspace = true, features = ["arbitrary", "serde"] }
+alloy-consensus = { workspace = true, features = ["serde"] }
 alloy-primitives = { workspace = true, features = ["rand", "rlp"] }
 alloy-rlp = { workspace = true, features = ["arrayvec"] }
 alloy-rpc-types = { workspace = true, optional = true }
@@ -96,6 +96,7 @@ arbitrary = [
     "nybbles/arbitrary",
     "alloy-trie/arbitrary",
     "alloy-chains/arbitrary",
+    "alloy-consensus/arbitrary",
     "alloy-eips/arbitrary",
     "dep:arbitrary",
     "dep:proptest",


### PR DESCRIPTION
This allows to user `reth-primtives` with risc0 compilation target.

I know that this PR might cause controversy as it adds extra feature to peers package, but at least I would like to bring it to a discussion.

PR Placeholder to test CI