### PR TITLE
Exploration fixing features

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -189,3 +189,19 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+
+  features:
+    name: features
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - run: make check-features
+        env:
+          RUSTFLAGS: -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8013,7 +8013,6 @@ dependencies = [
  "tempfile",
  "test-fuzz",
  "thiserror",
- "thread_local",
  "toml",
  "triehash",
  "zstd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8012,7 +8012,7 @@ dependencies = [
  "sucds",
  "tempfile",
  "test-fuzz",
- "thiserror-no-std",
+ "thiserror",
  "thread_local",
  "toml",
  "triehash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8013,6 +8013,7 @@ dependencies = [
  "tempfile",
  "test-fuzz",
  "thiserror-no-std",
+ "thread_local",
  "toml",
  "triehash",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,7 +387,7 @@ revm-inspectors = "0.5"
 
 # eth
 alloy-chains = "0.1.18"
-alloy-primitives = "0.7.2"
+alloy-primitives = { version = "0.7.2", default-features = false }
 alloy-dyn-abi = "0.7.2"
 alloy-sol-types = "0.7.2"
 alloy-rlp = "0.3.4"

--- a/Makefile
+++ b/Makefile
@@ -470,3 +470,11 @@ pr:
 	make lint && \
 	make update-book-cli && \
 	make test
+
+check-features:
+	cargo hack check \
+		--package reth-primitives-traits \
+		--package reth-primitives \
+		--package reth-rpc-types \
+		--package reth-codecs \
+		--feature-powerset

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -45,13 +45,13 @@ once_cell.workspace = true
 rayon.workspace = true
 serde.workspace = true
 tempfile = { workspace = true, optional = true }
-thiserror-no-std = { workspace = true, default-features = false }
+thiserror = { workspace = true, default-features = false, optional = true }
 zstd = { workspace = true, features = ["experimental"], optional = true }
 
 # arbitrary utils
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 proptest = { workspace = true, optional = true }
-thread_local = "1.1.8"
+thread_local = { version = "1.1.8", optional = true }
 # proptest-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -88,8 +88,8 @@ secp256k1.workspace = true
 
 [features]
 default = ["c-kzg", "alloy-compat", "std", "reth-codec"]
-std = ["thiserror-no-std/std", "reth-primitives-traits/std"]
-reth-codec = ["dep:reth-codecs", "dep:zstd", "dep:modular-bitfield"]
+std = ["dep:thiserror", "reth-primitives-traits/std", "dep:thread_local"]
+reth-codec = ["dep:reth-codecs", "dep:zstd", "dep:modular-bitfield", "dep:thread_local"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 arbitrary = [
     "std",
@@ -104,7 +104,7 @@ arbitrary = [
     "dep:proptest",
     "reth-codec",
 ]
-c-kzg = ["dep:c-kzg", "revm-primitives/c-kzg", "dep:tempfile", "alloy-eips/kzg"]
+c-kzg = ["dep:c-kzg", "revm-primitives/c-kzg", "dep:tempfile", "alloy-eips/kzg", "std"]
 optimism = [
     "reth-chainspec/optimism",
     "reth-ethereum-forks/optimism",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -45,13 +45,12 @@ once_cell.workspace = true
 rayon.workspace = true
 serde.workspace = true
 tempfile = { workspace = true, optional = true }
-thiserror = { workspace = true, default-features = false, optional = true }
+thiserror = { workspace = true, optional = true }
 zstd = { workspace = true, features = ["experimental"], optional = true }
 
 # arbitrary utils
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 proptest = { workspace = true, optional = true }
-thread_local = { version = "1.1.8", optional = true }
 # proptest-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -88,8 +87,8 @@ secp256k1.workspace = true
 
 [features]
 default = ["c-kzg", "alloy-compat", "std", "reth-codec"]
-std = ["dep:thiserror", "reth-primitives-traits/std", "dep:thread_local"]
-reth-codec = ["dep:reth-codecs", "dep:zstd", "dep:modular-bitfield", "dep:thread_local"]
+std = ["dep:thiserror", "reth-primitives-traits/std"]
+reth-codec = ["dep:reth-codecs", "dep:zstd", "dep:modular-bitfield"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 arbitrary = [
     "std",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -51,6 +51,7 @@ zstd = { workspace = true, features = ["experimental"], optional = true }
 # arbitrary utils
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 proptest = { workspace = true, optional = true }
+thread_local = "1.1.8"
 # proptest-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -91,6 +92,7 @@ std = ["thiserror-no-std/std", "reth-primitives-traits/std"]
 reth-codec = ["dep:reth-codecs", "dep:zstd", "dep:modular-bitfield"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 arbitrary = [
+    "std",
     "reth-primitives-traits/arbitrary",
     "revm-primitives/arbitrary",
     "reth-chainspec?/arbitrary",

--- a/crates/primitives/src/alloy_compat.rs
+++ b/crates/primitives/src/alloy_compat.rs
@@ -11,6 +11,9 @@ use alloy_rlp::Error as RlpError;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+#[cfg(not(feature = "std"))]
+use crate::alloc::string::ToString;
+
 impl TryFrom<alloy_rpc_types::Block> for Block {
     type Error = alloy_rpc_types::ConversionError;
 
@@ -43,7 +46,7 @@ impl TryFrom<alloy_rpc_types::Block> for Block {
                     // alloy deserializes empty blocks into `BlockTransactions::Hashes`, if the tx
                     // root is the empty root then we can just return an empty vec.
                     if block.header.transactions_root == EMPTY_TRANSACTIONS {
-                        Ok(vec![])
+                        Ok(Vec::new())
                     } else {
                         Err(ConversionError::MissingFullTransactions)
                     }

--- a/crates/primitives/src/compression/mod.rs
+++ b/crates/primitives/src/compression/mod.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "std")]
-use std::{thread_local};
-use core::cell::RefCell;
+use std::{cell::RefCell, thread_local};
 use zstd::bulk::{Compressor, Decompressor};
 
 #[cfg(not(feature = "std"))]
@@ -9,11 +8,10 @@ use alloc::vec::Vec;
 #[cfg(not(feature = "std"))]
 use alloc::string::ToString;
 
-#[cfg(not(feature = "std"))]
-use thread_local::ThreadLocal;
-
+#[cfg(feature = "std")]
 /// Compression/Decompression dictionary for `Receipt`.
 pub static RECEIPT_DICTIONARY: &[u8] = include_bytes!("./receipt_dictionary.bin");
+#[cfg(feature = "std")]
 /// Compression/Decompression dictionary for `Transaction`.
 pub static TRANSACTION_DICTIONARY: &[u8] = include_bytes!("./transaction_dictionary.bin");
 
@@ -47,16 +45,6 @@ thread_local! {
                 .expect("failed to initialize receipt decompressor"),
         ));
 }
-
-#[cfg(not(feature = "std"))]
-pub static TRANSACTION_COMPRESSOR: ThreadLocal<RefCell<Compressor<'static>>> = ThreadLocal::new();
-#[cfg(not(feature = "std"))]
-pub static TRANSACTION_DECOMPRESSOR: ThreadLocal<RefCell<ReusableDecompressor>> = ThreadLocal::new();
-#[cfg(not(feature = "std"))]
-pub static RECEIPT_COMPRESSOR: ThreadLocal<RefCell<Compressor<'static>>> = ThreadLocal::new();
-#[cfg(not(feature = "std"))]
-pub static RECEIPT_DECOMPRESSOR: ThreadLocal<RefCell<ReusableDecompressor>> = ThreadLocal::new();
-
 
 
 /// Reusable decompressor that uses its own internal buffer.

--- a/crates/primitives/src/compression/mod.rs
+++ b/crates/primitives/src/compression/mod.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "std")]
 use std::{cell::RefCell, thread_local};
+#[cfg(not(feature = "std"))]
+use zstd::bulk::Decompressor;
 #[cfg(feature = "std")]
 use zstd::bulk::{Compressor, Decompressor};
-#[cfg(not(feature = "std"))]
-use zstd::bulk::{Decompressor};
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -48,7 +48,6 @@ thread_local! {
                 .expect("failed to initialize receipt decompressor"),
         ));
 }
-
 
 /// Reusable decompressor that uses its own internal buffer.
 #[allow(missing_debug_implementations)]

--- a/crates/primitives/src/compression/mod.rs
+++ b/crates/primitives/src/compression/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "std")]
 use std::{cell::RefCell, thread_local};
+#[cfg(feature = "std")]
 use zstd::bulk::{Compressor, Decompressor};
+#[cfg(not(feature = "std"))]
+use zstd::bulk::{Decompressor};
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -57,6 +60,7 @@ pub struct ReusableDecompressor {
 }
 
 impl ReusableDecompressor {
+    #[cfg(feature = "std")]
     fn new(decompressor: Decompressor<'static>) -> Self {
         Self { decompressor, buf: Vec::with_capacity(4096) }
     }

--- a/crates/primitives/src/compression/mod.rs
+++ b/crates/primitives/src/compression/mod.rs
@@ -1,8 +1,12 @@
-use std::{cell::RefCell, thread_local};
+use std::{thread_local};
+use core::cell::RefCell;
 use zstd::bulk::{Compressor, Decompressor};
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
 
 /// Compression/Decompression dictionary for `Receipt`.
 pub static RECEIPT_DICTIONARY: &[u8] = include_bytes!("./receipt_dictionary.bin");
@@ -74,7 +78,7 @@ impl ReusableDecompressor {
                     reserved_upper_bound = true;
                     if let Some(upper_bound) = Decompressor::upper_bound(src) {
                         if let Some(additional) = upper_bound.checked_sub(self.buf.capacity()) {
-                            break 'b additional
+                            break 'b additional;
                         }
                     }
                 }

--- a/crates/primitives/src/constants/eip4844.rs
+++ b/crates/primitives/src/constants/eip4844.rs
@@ -26,7 +26,7 @@ mod trusted_setup {
     }
 
     /// Error type for loading the trusted setup.
-    #[derive(Debug, thiserror_no_std::Error)]
+    #[derive(Debug, thiserror::Error)]
     pub enum LoadKzgSettingsError {
         /// Failed to create temp file to store bytes for loading [`KzgSettings`] via
         /// [`KzgSettings::load_trusted_setup_file`].

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -22,12 +22,6 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-#[cfg(all(feature = "reth-codec", feature = "std"))]
-use ::thread_local as _;
-
-#[cfg(all(feature = "c-kzg", feature = "std"))]
-use ::thread_local as _;
-
 #[cfg(feature = "alloy-compat")]
 mod alloy_compat;
 pub mod basefee;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -22,6 +22,12 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+#[cfg(all(feature = "reth-codec", feature = "std"))]
+use ::thread_local as _;
+
+#[cfg(all(feature = "c-kzg", feature = "std"))]
+use ::thread_local as _;
+
 #[cfg(feature = "alloy-compat")]
 mod alloy_compat;
 pub mod basefee;

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -6,18 +6,24 @@ use alloy_rlp::{length_of_length, Decodable, Encodable, RlpDecodable, RlpEncodab
 use bytes::{Buf, BufMut};
 use core::{cmp::Ordering, ops::Deref};
 use derive_more::{Deref, DerefMut, From, IntoIterator};
+#[cfg(all(feature = "reth-codec", not(feature = "std")))]
+use reth_codecs::Compact;
 #[cfg(all(feature = "reth-codec", feature = "std"))]
 use reth_codecs::{Compact, CompactZstd};
-#[cfg(all(feature = "reth-codec", not(feature = "std")))]
-use reth_codecs::{Compact};
 use serde::{Deserialize, Serialize};
 
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 
 /// Receipt containing result of transaction execution.
-#[cfg_attr(any(test, all(feature = "reth-codec", feature = "std")), reth_codecs::reth_codec(no_arbitrary, zstd))]
-#[cfg_attr(any(test, all(feature = "reth-codec", not(feature = "std"))), reth_codecs::reth_codec(no_arbitrary))]
+#[cfg_attr(
+    any(test, all(feature = "reth-codec", feature = "std")),
+    reth_codecs::reth_codec(no_arbitrary, zstd)
+)]
+#[cfg_attr(
+    any(test, all(feature = "reth-codec", not(feature = "std"))),
+    reth_codecs::reth_codec(no_arbitrary)
+)]
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests)]
 #[derive(
     Clone, Debug, PartialEq, Eq, Default, RlpEncodable, RlpDecodable, Serialize, Deserialize,
@@ -132,7 +138,7 @@ impl From<Vec<Receipt>> for Receipts {
 }
 
 impl FromIterator<Vec<Option<Receipt>>> for Receipts {
-    fn from_iter<I: IntoIterator<Item=Vec<Option<Receipt>>>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = Vec<Option<Receipt>>>>(iter: I) -> Self {
         iter.into_iter().collect::<Vec<_>>().into()
     }
 }
@@ -177,8 +183,8 @@ impl ReceiptWithBloom {
 }
 
 /// Retrieves gas spent by transactions as a vector of tuples (transaction index, gas used).
-pub fn gas_spent_by_transactions<T: Deref<Target=Receipt>>(
-    receipts: impl IntoIterator<Item=T>,
+pub fn gas_spent_by_transactions<T: Deref<Target = Receipt>>(
+    receipts: impl IntoIterator<Item = T>,
 ) -> Vec<(u64, u64)> {
     receipts
         .into_iter()

--- a/crates/primitives/src/receipt.rs
+++ b/crates/primitives/src/receipt.rs
@@ -21,7 +21,7 @@ use alloc::{vec, vec::Vec};
     reth_codecs::reth_codec(no_arbitrary, zstd)
 )]
 #[cfg_attr(
-    any(test, all(feature = "reth-codec", not(feature = "std"))),
+    all(not(test), feature = "reth-codec", not(feature = "std")),
     reth_codecs::reth_codec(no_arbitrary)
 )]
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests)]

--- a/crates/primitives/src/transaction/compat.rs
+++ b/crates/primitives/src/transaction/compat.rs
@@ -1,6 +1,10 @@
 use crate::{Address, Transaction, TransactionSigned, TxKind, U256};
 use revm_primitives::{AuthorizationList, TxEnv};
 
+
+#[cfg(all(not(feature = "std"), feature = "optimism"))]
+use alloc::vec::Vec;
+
 /// Implements behaviour to fill a [`TxEnv`] from another transaction.
 pub trait FillTxEnv {
     /// Fills [`TxEnv`] with an [`Address`] and transaction.

--- a/crates/primitives/src/transaction/compat.rs
+++ b/crates/primitives/src/transaction/compat.rs
@@ -1,7 +1,6 @@
 use crate::{Address, Transaction, TransactionSigned, TxKind, U256};
 use revm_primitives::{AuthorizationList, TxEnv};
 
-
 #[cfg(all(not(feature = "std"), feature = "optimism"))]
 use alloc::vec::Vec;
 

--- a/crates/primitives/src/transaction/error.rs
+++ b/crates/primitives/src/transaction/error.rs
@@ -3,7 +3,7 @@ use crate::{GotExpectedBoxed, U256};
 /// Represents error variants that can happen when trying to validate a
 /// [Transaction](crate::Transaction)
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "std", derive(thiserror_no_std::Error))]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum InvalidTransactionError {
     /// The sender does not have enough funds to cover the transaction fees
     #[cfg_attr(feature = "std", error(
@@ -60,7 +60,7 @@ pub enum InvalidTransactionError {
 /// Represents error variants that can happen when trying to convert a transaction to
 /// [`PooledTransactionsElement`](crate::PooledTransactionsElement)
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "std", derive(thiserror_no_std::Error))]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum TransactionConversionError {
     /// This error variant is used when a transaction cannot be converted into a
     /// [`PooledTransactionsElement`](crate::PooledTransactionsElement) because it is not supported
@@ -72,7 +72,7 @@ pub enum TransactionConversionError {
 /// Represents error variants than can happen when trying to convert a
 /// [`TransactionSignedEcRecovered`](crate::TransactionSignedEcRecovered) transaction.
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "std", derive(thiserror_no_std::Error))]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum TryFromRecoveredTransactionError {
     /// Thrown if the transaction type is unsupported.
     #[cfg_attr(feature = "std", error("Unsupported transaction type: {0}"))]

--- a/crates/primitives/src/transaction/error.rs
+++ b/crates/primitives/src/transaction/error.rs
@@ -16,7 +16,10 @@ pub enum InvalidTransactionError {
     #[cfg_attr(feature = "std", error("transaction nonce is not consistent"))]
     NonceNotConsistent,
     /// The transaction is before Spurious Dragon and has a chain ID.
-    #[cfg_attr(feature = "std", error("transactions before Spurious Dragon should not have a chain ID"))]
+    #[cfg_attr(
+        feature = "std",
+        error("transactions before Spurious Dragon should not have a chain ID")
+    )]
     OldLegacyChainId,
     /// The chain ID in the transaction does not match the current network configuration.
     #[cfg_attr(feature = "std", error("transaction's chain ID does not match"))]

--- a/crates/primitives/src/transaction/error.rs
+++ b/crates/primitives/src/transaction/error.rs
@@ -2,79 +2,82 @@ use crate::{GotExpectedBoxed, U256};
 
 /// Represents error variants that can happen when trying to validate a
 /// [Transaction](crate::Transaction)
-#[derive(Debug, Clone, Eq, PartialEq, thiserror_no_std::Error)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "std", derive(thiserror_no_std::Error))]
 pub enum InvalidTransactionError {
     /// The sender does not have enough funds to cover the transaction fees
-    #[error(
+    #[cfg_attr(feature = "std", error(
         "sender does not have enough funds ({}) to cover transaction fees: {}", _0.got, _0.expected
-    )]
+    ))]
     InsufficientFunds(GotExpectedBoxed<U256>),
     /// The nonce is lower than the account's nonce, or there is a nonce gap present.
     ///
     /// This is a consensus error.
-    #[error("transaction nonce is not consistent")]
+    #[cfg_attr(feature = "std", error("transaction nonce is not consistent"))]
     NonceNotConsistent,
     /// The transaction is before Spurious Dragon and has a chain ID.
-    #[error("transactions before Spurious Dragon should not have a chain ID")]
+    #[cfg_attr(feature = "std", error("transactions before Spurious Dragon should not have a chain ID"))]
     OldLegacyChainId,
     /// The chain ID in the transaction does not match the current network configuration.
-    #[error("transaction's chain ID does not match")]
+    #[cfg_attr(feature = "std", error("transaction's chain ID does not match"))]
     ChainIdMismatch,
     /// The transaction requires EIP-2930 which is not enabled currently.
-    #[error("EIP-2930 transactions are disabled")]
+    #[cfg_attr(feature = "std", error("EIP-2930 transactions are disabled"))]
     Eip2930Disabled,
     /// The transaction requires EIP-1559 which is not enabled currently.
-    #[error("EIP-1559 transactions are disabled")]
+    #[cfg_attr(feature = "std", error("EIP-1559 transactions are disabled"))]
     Eip1559Disabled,
     /// The transaction requires EIP-4844 which is not enabled currently.
-    #[error("EIP-4844 transactions are disabled")]
+    #[cfg_attr(feature = "std", error("EIP-4844 transactions are disabled"))]
     Eip4844Disabled,
     /// The transaction requires EIP-7702 which is not enabled currently.
-    #[error("EIP-7702 transactions are disabled")]
+    #[cfg_attr(feature = "std", error("EIP-7702 transactions are disabled"))]
     Eip7702Disabled,
     /// Thrown if a transaction is not supported in the current network configuration.
-    #[error("transaction type not supported")]
+    #[cfg_attr(feature = "std", error("transaction type not supported"))]
     TxTypeNotSupported,
     /// The calculated gas of the transaction exceeds `u64::MAX`.
-    #[error("gas overflow (maximum of u64)")]
+    #[cfg_attr(feature = "std", error("gas overflow (maximum of u64)"))]
     GasUintOverflow,
     /// The transaction is specified to use less gas than required to start the invocation.
-    #[error("intrinsic gas too low")]
+    #[cfg_attr(feature = "std", error("intrinsic gas too low"))]
     GasTooLow,
     /// The transaction gas exceeds the limit
-    #[error("intrinsic gas too high")]
+    #[cfg_attr(feature = "std", error("intrinsic gas too high"))]
     GasTooHigh,
     /// Thrown to ensure no one is able to specify a transaction with a tip higher than the total
     /// fee cap.
-    #[error("max priority fee per gas higher than max fee per gas")]
+    #[cfg_attr(feature = "std", error("max priority fee per gas higher than max fee per gas"))]
     TipAboveFeeCap,
     /// Thrown post London if the transaction's fee is less than the base fee of the block.
-    #[error("max fee per gas less than block base fee")]
+    #[cfg_attr(feature = "std", error("max fee per gas less than block base fee"))]
     FeeCapTooLow,
     /// Thrown if the sender of a transaction is a contract.
-    #[error("transaction signer has bytecode set")]
+    #[cfg_attr(feature = "std", error("transaction signer has bytecode set"))]
     SignerAccountHasBytecode,
 }
 
 /// Represents error variants that can happen when trying to convert a transaction to
 /// [`PooledTransactionsElement`](crate::PooledTransactionsElement)
-#[derive(Debug, Clone, Eq, PartialEq, thiserror_no_std::Error)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "std", derive(thiserror_no_std::Error))]
 pub enum TransactionConversionError {
     /// This error variant is used when a transaction cannot be converted into a
     /// [`PooledTransactionsElement`](crate::PooledTransactionsElement) because it is not supported
     /// for P2P network.
-    #[error("Transaction is not supported for p2p")]
+    #[cfg_attr(feature = "std", error("Transaction is not supported for p2p"))]
     UnsupportedForP2P,
 }
 
 /// Represents error variants than can happen when trying to convert a
 /// [`TransactionSignedEcRecovered`](crate::TransactionSignedEcRecovered) transaction.
-#[derive(Debug, Clone, Eq, PartialEq, thiserror_no_std::Error)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "std", derive(thiserror_no_std::Error))]
 pub enum TryFromRecoveredTransactionError {
     /// Thrown if the transaction type is unsupported.
-    #[error("Unsupported transaction type: {0}")]
+    #[cfg_attr(feature = "std", error("Unsupported transaction type: {0}"))]
     UnsupportedTransactionType(u8),
     /// This error variant is used when a blob sidecar is missing.
-    #[error("Blob sidecar missing for an EIP-4844 transaction")]
+    #[cfg_attr(feature = "std", error("Blob sidecar missing for an EIP-4844 transaction"))]
     BlobSidecarMissing,
 }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -898,7 +898,7 @@ impl TransactionSignedNoHash {
     /// [`Self::recover_signer`].
     pub fn recover_signers<'a, T>(txes: T, num_txes: usize) -> Option<Vec<Address>>
     where
-        T: IntoParallelIterator<Item=&'a Self> + IntoIterator<Item=&'a Self> + Send,
+        T: IntoParallelIterator<Item = &'a Self> + IntoIterator<Item = &'a Self> + Send,
     {
         if num_txes < *PARALLEL_SENDER_RECOVERY_THRESHOLD {
             txes.into_iter().map(|tx| tx.recover_signer()).collect()
@@ -1078,7 +1078,7 @@ impl TransactionSigned {
     /// [`Self::recover_signer`].
     pub fn recover_signers<'a, T>(txes: T, num_txes: usize) -> Option<Vec<Address>>
     where
-        T: IntoParallelIterator<Item=&'a Self> + IntoIterator<Item=&'a Self> + Send,
+        T: IntoParallelIterator<Item = &'a Self> + IntoIterator<Item = &'a Self> + Send,
     {
         if num_txes < *PARALLEL_SENDER_RECOVERY_THRESHOLD {
             txes.into_iter().map(|tx| tx.recover_signer()).collect()
@@ -1094,7 +1094,7 @@ impl TransactionSigned {
     /// [`Self::recover_signer_unchecked`].
     pub fn recover_signers_unchecked<'a, T>(txes: T, num_txes: usize) -> Option<Vec<Address>>
     where
-        T: IntoParallelIterator<Item=&'a Self> + IntoIterator<Item=&'a Self>,
+        T: IntoParallelIterator<Item = &'a Self> + IntoIterator<Item = &'a Self>,
     {
         if num_txes < *PARALLEL_SENDER_RECOVERY_THRESHOLD {
             txes.into_iter().map(|tx| tx.recover_signer_unchecked()).collect()

--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -3,10 +3,10 @@ use alloy_rlp::{
     length_of_length, Decodable, Encodable, Error as DecodeError, Header, EMPTY_STRING_CODE,
 };
 use bytes::Buf;
+use core::mem;
 #[cfg(feature = "reth-codec")]
 use reth_codecs::{reth_codec, Compact};
 use serde::{Deserialize, Serialize};
-use core::mem;
 
 /// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codec)]

--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -3,9 +3,10 @@ use alloy_rlp::{
     length_of_length, Decodable, Encodable, Error as DecodeError, Header, EMPTY_STRING_CODE,
 };
 use bytes::Buf;
+#[cfg(feature = "reth-codec")]
 use reth_codecs::{reth_codec, Compact};
 use serde::{Deserialize, Serialize};
-use std::mem;
+use core::mem;
 
 /// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codec)]

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -40,5 +40,5 @@ bytes.workspace = true
 serde_json.workspace = true
 
 [features]
-default = ["jsonrpsee-types"]
+default = ["dep:jsonrpsee-types"]
 arbitrary = ["alloy-primitives/arbitrary", "alloy-rpc-types/arbitrary"]

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 # ethereum
 alloy-primitives = { workspace = true, features = ["rand", "rlp", "serde"] }
-alloy-rpc-types = { workspace = true, features = ["jsonrpsee-types"] }
+alloy-rpc-types = { workspace = true }
 alloy-rpc-types-admin.workspace = true
 alloy-rpc-types-anvil.workspace = true
 alloy-rpc-types-beacon.workspace = true
@@ -23,7 +23,7 @@ alloy-rpc-types-mev.workspace = true
 alloy-rpc-types-trace.workspace = true
 alloy-rpc-types-txpool.workspace = true
 alloy-serde.workspace = true
-alloy-rpc-types-engine = { workspace = true, features = ["jsonrpsee-types"] }
+alloy-rpc-types-engine = { workspace = true }
 
 # misc
 jsonrpsee-types = { workspace = true, optional = true }
@@ -40,5 +40,5 @@ bytes.workspace = true
 serde_json.workspace = true
 
 [features]
-default = ["dep:jsonrpsee-types"]
+default = ["dep:jsonrpsee-types", "alloy-rpc-types/jsonrpsee-types", "alloy-rpc-types-engine/jsonrpsee-types"]
 arbitrary = ["alloy-primitives/arbitrary", "alloy-rpc-types/arbitrary"]

--- a/crates/rpc/rpc-types/Cargo.toml
+++ b/crates/rpc/rpc-types/Cargo.toml
@@ -18,12 +18,12 @@ alloy-primitives = { workspace = true, features = ["rand", "rlp", "serde"] }
 alloy-rpc-types = { workspace = true }
 alloy-rpc-types-admin.workspace = true
 alloy-rpc-types-anvil.workspace = true
-alloy-rpc-types-beacon.workspace = true
+alloy-rpc-types-beacon = { workspace = true, optional = true }
 alloy-rpc-types-mev.workspace = true
 alloy-rpc-types-trace.workspace = true
 alloy-rpc-types-txpool.workspace = true
 alloy-serde.workspace = true
-alloy-rpc-types-engine = { workspace = true }
+alloy-rpc-types-engine = { workspace = true, optional = true }
 
 # misc
 jsonrpsee-types = { workspace = true, optional = true }
@@ -40,5 +40,11 @@ bytes.workspace = true
 serde_json.workspace = true
 
 [features]
-default = ["dep:jsonrpsee-types", "alloy-rpc-types/jsonrpsee-types", "alloy-rpc-types-engine/jsonrpsee-types"]
+default = [
+    "dep:jsonrpsee-types",
+    "dep:alloy-rpc-types-beacon",
+    "dep:alloy-rpc-types-engine",
+    "alloy-rpc-types/jsonrpsee-types",
+    "alloy-rpc-types-engine/jsonrpsee-types"
+]
 arbitrary = ["alloy-primitives/arbitrary", "alloy-rpc-types/arbitrary"]

--- a/crates/rpc/rpc-types/src/eth/error.rs
+++ b/crates/rpc/rpc-types/src/eth/error.rs
@@ -1,9 +1,8 @@
 //! Implementation specific Errors for the `eth_` namespace.
 
-use jsonrpsee_types::ErrorObject;
-
 /// A trait to convert an error to an RPC error.
+#[cfg(feature = "default")]
 pub trait ToRpcError: std::error::Error + Send + Sync + 'static {
     /// Converts the error to a JSON-RPC error object.
-    fn to_rpc_error(&self) -> ErrorObject<'static>;
+    fn to_rpc_error(&self) -> jsonrpsee_types::ErrorObject<'static>;
 }

--- a/crates/rpc/rpc-types/src/eth/mod.rs
+++ b/crates/rpc/rpc-types/src/eth/mod.rs
@@ -4,4 +4,5 @@ pub(crate) mod error;
 pub mod transaction;
 
 // re-export
+#[cfg(feature = "default")]
 pub use alloy_rpc_types_engine as engine;

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -51,6 +51,7 @@ pub use eth::{
     engine::{
         ExecutionPayload, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, PayloadError,
     },
-    error::ToRpcError,
     transaction::{self, TransactionRequest, TypedTransactionRequest},
 };
+#[cfg(feature = "default")]
+pub use eth::error::ToRpcError;

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -46,6 +46,8 @@ pub use alloy_rpc_types_beacon as beacon;
 pub use alloy_rpc_types_txpool as txpool;
 
 // Ethereum specific rpc types related to typed transaction requests and the engine API.
+#[cfg(feature = "default")]
+pub use eth::error::ToRpcError;
 pub use eth::{
     engine,
     engine::{
@@ -53,5 +55,3 @@ pub use eth::{
     },
     transaction::{self, TransactionRequest, TypedTransactionRequest},
 };
-#[cfg(feature = "default")]
-pub use eth::error::ToRpcError;

--- a/crates/rpc/rpc-types/src/lib.rs
+++ b/crates/rpc/rpc-types/src/lib.rs
@@ -40,6 +40,7 @@ pub use alloy_rpc_types_anvil as anvil;
 pub use alloy_rpc_types_mev as mev;
 
 // re-export beacon
+#[cfg(feature = "default")]
 pub use alloy_rpc_types_beacon as beacon;
 
 // re-export txpool
@@ -48,10 +49,11 @@ pub use alloy_rpc_types_txpool as txpool;
 // Ethereum specific rpc types related to typed transaction requests and the engine API.
 #[cfg(feature = "default")]
 pub use eth::error::ToRpcError;
+pub use eth::transaction::{self, TransactionRequest, TypedTransactionRequest};
+#[cfg(feature = "default")]
 pub use eth::{
     engine,
     engine::{
         ExecutionPayload, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, PayloadError,
     },
-    transaction::{self, TransactionRequest, TypedTransactionRequest},
 };

--- a/crates/storage/codecs/Cargo.toml
+++ b/crates/storage/codecs/Cargo.toml
@@ -18,7 +18,7 @@ reth-codecs-derive = { path = "./derive", default-features = false }
 alloy-consensus = { workspace = true, optional = true }
 alloy-eips = { workspace = true, optional = true }
 alloy-genesis = { workspace = true, optional = true }
-alloy-primitives.workspace = true
+alloy-primitives = { workspace = true, default-features = false }
 alloy-trie = { workspace = true, optional = true }
 
 # misc
@@ -43,7 +43,7 @@ proptest-arbitrary-interop.workspace = true
 
 [features]
 default = ["std", "alloy"]
-std = ["alloy-primitives/std", "bytes/std", "serde/std"]
+std = ["alloy-primitives/std", "bytes/std", "serde?/std"]
 alloy = [
     "dep:alloy-consensus",
     "dep:alloy-eips",

--- a/crates/storage/codecs/Cargo.toml
+++ b/crates/storage/codecs/Cargo.toml
@@ -50,4 +50,5 @@ alloy = [
     "dep:alloy-genesis",
     "dep:modular-bitfield",
     "dep:alloy-trie",
+    "dep:serde"
 ]

--- a/crates/storage/codecs/src/alloy/access_list.rs
+++ b/crates/storage/codecs/src/alloy/access_list.rs
@@ -8,7 +8,7 @@ impl Compact for AccessListItem {
     where
         B: bytes::BufMut + AsMut<[u8]>,
     {
-        let mut buffer = Vec::new();
+        let mut buffer = crate::Vec::new();
         self.address.to_compact(&mut buffer);
         self.storage_keys.specialized_to_compact(&mut buffer);
         buf.put(&buffer[..]);
@@ -18,7 +18,7 @@ impl Compact for AccessListItem {
     fn from_compact(mut buf: &[u8], _: usize) -> (Self, &[u8]) {
         let (address, new_buf) = Address::from_compact(buf, buf.len());
         buf = new_buf;
-        let (storage_keys, new_buf) = Vec::specialized_from_compact(buf, buf.len());
+        let (storage_keys, new_buf) = crate::Vec::specialized_from_compact(buf, buf.len());
         buf = new_buf;
         let access_list_item = Self { address, storage_keys };
         (access_list_item, buf)
@@ -30,14 +30,14 @@ impl Compact for AccessList {
     where
         B: bytes::BufMut + AsMut<[u8]>,
     {
-        let mut buffer = Vec::new();
+        let mut buffer = crate::Vec::new();
         self.0.to_compact(&mut buffer);
         buf.put(&buffer[..]);
         buffer.len()
     }
 
     fn from_compact(mut buf: &[u8], _: usize) -> (Self, &[u8]) {
-        let (access_list_items, new_buf) = Vec::from_compact(buf, buf.len());
+        let (access_list_items, new_buf) = crate::Vec::from_compact(buf, buf.len());
         buf = new_buf;
         let access_list = Self(access_list_items);
         (access_list, buf)

--- a/crates/storage/codecs/src/alloy/genesis_account.rs
+++ b/crates/storage/codecs/src/alloy/genesis_account.rs
@@ -4,6 +4,8 @@ use alloy_primitives::{Bytes, B256, U256};
 use reth_codecs_derive::reth_codec;
 use serde::{Deserialize, Serialize};
 
+use crate::Vec;
+
 /// GenesisAccount acts as bridge which simplifies Compact implementation for AlloyGenesisAccount.
 ///
 /// Notice: Make sure this struct is 1:1 with `alloy_genesis::GenesisAccount`

--- a/crates/storage/codecs/src/alloy/log.rs
+++ b/crates/storage/codecs/src/alloy/log.rs
@@ -1,6 +1,6 @@
 //! Native Compact codec impl for primitive alloy log types.
 
-use crate::Compact;
+use crate::{Compact, Vec};
 use alloy_primitives::{Address, Bytes, Log, LogData};
 use bytes::BufMut;
 

--- a/crates/storage/codecs/src/alloy/trie.rs
+++ b/crates/storage/codecs/src/alloy/trie.rs
@@ -1,6 +1,6 @@
 //! Native Compact codec impl for EIP-7685 requests.
 
-use crate::Compact;
+use crate::{Compact, Vec};
 use alloy_primitives::B256;
 use alloy_trie::{hash_builder::HashBuilderValue, BranchNodeCompact, TrieMask};
 use bytes::{Buf, BufMut};

--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -19,6 +19,8 @@
 
 pub use reth_codecs_derive::*;
 
+// use serde as _;
+
 use alloy_primitives::{Address, Bloom, Bytes, FixedBytes, U256};
 use bytes::{Buf, BufMut};
 

--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -19,8 +19,6 @@
 
 pub use reth_codecs_derive::*;
 
-// use serde as _;
-
 use alloy_primitives::{Address, Bloom, Bytes, FixedBytes, U256};
 use bytes::{Buf, BufMut};
 

--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -26,6 +26,8 @@ use bytes::{Buf, BufMut};
 extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
 
 #[cfg(any(test, feature = "alloy"))]
 mod alloy;


### PR DESCRIPTION
## Description 

This PR adds [`cargo hack`](https://github.com/taiki-e/cargo-hack) to validate that crates `` can compile with all feature combinations.

This check fails on version `1.0.3`, so this PR also contains fixes for it.

## Main fixes

* remove `thiserror-no-std` in favor of original `thiserror` and feature gate it behind `std`.
* `zstd` is only supported together with `std`, as it is very hard to get `zstd` work in `no_std`
* `c-kzg` is only supported together with `std`, for similar reason as `zstd`.
* put all jsonrpsee related types in `reth-rpc-types` behind `default` feature flag, so it is possible to compile it for riscv
* Minor fixes in depedencies feature-gating