### PR TITLE
Draft of primitive-types check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8090,7 +8090,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "test-fuzz",
- "thiserror-no-std",
+ "thiserror",
  "toml",
  "zstd",
 ]

--- a/Makefile
+++ b/Makefile
@@ -471,4 +471,5 @@ pr:
 check-features:
 	cargo hack check \
 		--package reth-codecs \
+		--package reth-primitives \
 		--feature-powerset

--- a/Makefile
+++ b/Makefile
@@ -471,5 +471,6 @@ pr:
 check-features:
 	cargo hack check \
 		--package reth-codecs \
+		--package reth-primitives-traits \
 		--package reth-primitives \
 		--feature-powerset

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -46,7 +46,7 @@ once_cell.workspace = true
 rayon.workspace = true
 serde.workspace = true
 tempfile = { workspace = true, optional = true }
-thiserror-no-std = { workspace = true, default-features = false, optional = true }
+thiserror = { workspace = true, optional = true }
 zstd = { workspace = true, features = ["experimental"], optional = true }
 
 # arbitrary utils
@@ -81,8 +81,8 @@ pprof = { workspace = true, features = [
 
 [features]
 default = ["c-kzg", "alloy-compat", "std", "reth-codec", "secp256k1"]
-std = ["thiserror-no-std?/std", "reth-primitives-traits/std"]
-reth-codec = ["dep:reth-codecs", "dep:zstd", "dep:modular-bitfield"]
+std = ["thiserror", "reth-primitives-traits/std"]
+reth-codec = ["dep:reth-codecs", "dep:zstd", "dep:modular-bitfield", "std"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 arbitrary = [
     "reth-primitives-traits/arbitrary",
@@ -95,7 +95,7 @@ arbitrary = [
     "reth-codec",
 ]
 secp256k1 = ["dep:secp256k1"]
-c-kzg = ["dep:c-kzg", "revm-primitives/c-kzg", "dep:tempfile", "alloy-eips/kzg", "dep:thiserror-no-std"]
+c-kzg = ["dep:c-kzg", "revm-primitives/c-kzg", "dep:tempfile", "alloy-eips/kzg"]
 optimism = [
     "reth-chainspec/optimism",
     "reth-ethereum-forks/optimism",

--- a/crates/primitives/src/alloy_compat.rs
+++ b/crates/primitives/src/alloy_compat.rs
@@ -10,6 +10,8 @@ use alloy_rlp::Error as RlpError;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use crate::alloc::string::ToString;
 
 impl TryFrom<alloy_rpc_types::Block> for Block {
     type Error = alloy_rpc_types::ConversionError;
@@ -43,7 +45,7 @@ impl TryFrom<alloy_rpc_types::Block> for Block {
                     // alloy deserializes empty blocks into `BlockTransactions::Hashes`, if the tx
                     // root is the empty root then we can just return an empty vec.
                     if block.header.transactions_root == EMPTY_TRANSACTIONS {
-                        Ok(vec![])
+                        Ok(Vec::new())
                     } else {
                         Err(ConversionError::MissingFullTransactions)
                     }

--- a/crates/primitives/src/alloy_compat.rs
+++ b/crates/primitives/src/alloy_compat.rs
@@ -9,9 +9,7 @@ use alloy_primitives::TxKind;
 use alloy_rlp::Error as RlpError;
 
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-#[cfg(not(feature = "std"))]
-use crate::alloc::string::ToString;
+use alloc::{string::ToString, vec::Vec};
 
 impl TryFrom<alloy_rpc_types::Block> for Block {
     type Error = alloy_rpc_types::ConversionError;

--- a/crates/primitives/src/constants/eip4844.rs
+++ b/crates/primitives/src/constants/eip4844.rs
@@ -1,5 +1,5 @@
 //! [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844#parameters) protocol constants and utils for shard Blob Transactions.
-#[cfg(feature = "c-kzg")]
+#[cfg(all(feature = "c-kzg", feature = "std"))]
 pub use trusted_setup::*;
 
 pub use alloy_eips::eip4844::{
@@ -7,6 +7,12 @@ pub use alloy_eips::eip4844::{
     FIELD_ELEMENTS_PER_BLOB, FIELD_ELEMENT_BYTES, MAX_BLOBS_PER_BLOCK, MAX_DATA_GAS_PER_BLOCK,
     TARGET_BLOBS_PER_BLOCK, TARGET_DATA_GAS_PER_BLOCK, VERSIONED_HASH_VERSION_KZG,
 };
+
+// These 2 to silence unused
+#[cfg(all(feature = "c-kzg", not(feature = "std")))]
+use tempfile as _;
+#[cfg(all(not(feature = "c-kzg"), feature = "std"))]
+use thiserror as _;
 
 #[cfg(all(feature = "c-kzg", feature = "std"))]
 mod trusted_setup {
@@ -26,7 +32,7 @@ mod trusted_setup {
     }
 
     /// Error type for loading the trusted setup.
-    #[derive(Debug, thiserror_no_std::Error)]
+    #[derive(Debug, thiserror::Error)]
     pub enum LoadKzgSettingsError {
         /// Failed to create temp file to store bytes for loading [`KzgSettings`] via
         /// [`KzgSettings::load_trusted_setup_file`].

--- a/crates/primitives/src/transaction/compat.rs
+++ b/crates/primitives/src/transaction/compat.rs
@@ -1,6 +1,9 @@
 use crate::{Address, Transaction, TransactionSigned, TxKind, U256};
 use revm_primitives::{AuthorizationList, TxEnv};
 
+#[cfg(all(not(feature = "std"), feature = "optimism"))]
+use alloc::vec::Vec;
+
 /// Implements behaviour to fill a [`TxEnv`] from another transaction.
 pub trait FillTxEnv {
     /// Fills [`TxEnv`] with an [`Address`] and transaction.

--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -3,9 +3,10 @@ use alloy_rlp::{
     length_of_length, Decodable, Encodable, Error as DecodeError, Header, EMPTY_STRING_CODE,
 };
 use bytes::Buf;
+#[cfg(any(test, feature = "reth-codec"))]
 use reth_codecs::{reth_codec, Compact};
 use serde::{Deserialize, Serialize};
-use std::mem;
+use core::mem;
 
 /// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codec)]


### PR DESCRIPTION
* `c-kgz` does not need `thiserror` dependency.
* `c-kgz` constants are only available with `std` 
* `reth-codecs` feature only available with `std`